### PR TITLE
Windows ARM64 self-hosted runner support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
 
   build:
     needs: schedule
-    runs-on: windows-latest
 
     if: ${{ needs.schedule.outputs.build-plan != '[]' }}
     strategy:
@@ -76,6 +75,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.schedule.outputs.build-plan) }}
     name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
 
@@ -84,6 +84,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+        architecture: ${{ startsWith(matrix.name, 'clangarm') && 'x86' || 'x64' }}
 
     - uses: actions/cache@v2
       with:
@@ -99,6 +100,7 @@ jobs:
         python -m pip install --user 'wheel==0.36.2'
         python -m pip install --user -r requirements.txt
 
+    # Note that released ARM64 requires x86 msys, but this will install x64
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MSYS
@@ -112,6 +114,7 @@ jobs:
         sed -e "s|Include = /etc/pacman.d/mirrorlist.mingw64|Server = http://repo.msys2.org/mingw/x86_64/|g" -i /etc/pacman.conf
         sed -e "s|Include = /etc/pacman.d/mirrorlist.msys|Server = http://repo.msys2.org/msys/\$arch/|g" -i /etc/pacman.conf
         sed -i '1s|^|[clang32]\nServer = http://repo.msys2.org/mingw/clang32/\n|' /etc/pacman.conf
+        sed -i '1s|^|[clangarm64]\nServer = http://repo.msys2.org/mingw/clangarm64/\n|' /etc/pacman.conf
         pacman-conf.exe
 
     - name: Update using the main mirror & Check install
@@ -121,9 +124,9 @@ jobs:
         msys2 -c 'pacman -Qkq'
 
     - name: Install extra packages
-      if: ${{ startsWith(matrix.name, 'clang32') }}
+      if: ${{ startsWith(matrix.name, 'clang32') || startsWith(matrix.name, 'clangarm64') }}
       run: |
-        msys2 -c 'pacman --noconfirm -S mingw-w64-clang-i686-toolchain'
+        msys2 -c 'pacman --noconfirm -S mingw-w64-clang-${{ startsWith(matrix.name, 'clangarm64') && 'aarch64' || 'i686' }}-toolchain'
 
     - name: Init git
       shell: msys2 {0}

--- a/autobuild.py
+++ b/autobuild.py
@@ -838,42 +838,56 @@ JOB_META: List[Dict[str, Any]] = [
         "matrix": {
             "packages": "base-devel mingw-w64-x86_64-toolchain git",
             "build-args": "--build-types mingw64",
-            "name": "mingw64"
+            "name": "mingw64",
+            "runner": "windows-latest"
         }
     }, {
         "build-types": ["mingw32"],
         "matrix": {
             "packages": "base-devel mingw-w64-i686-toolchain git",
             "build-args": "--build-types mingw32",
-            "name": "mingw32"
+            "name": "mingw32",
+            "runner": "windows-latest"
         }
     }, {
         "build-types": ["ucrt64"],
         "matrix": {
             "packages": "base-devel mingw-w64-ucrt-x86_64-toolchain git",
             "build-args": "--build-types ucrt64",
-            "name": "ucrt64"
+            "name": "ucrt64",
+            "runner": "windows-latest"
         }
     }, {
         "build-types": ["clang64"],
         "matrix": {
             "packages": "base-devel mingw-w64-clang-x86_64-toolchain git",
             "build-args": "--build-types clang64",
-            "name": "clang64"
+            "name": "clang64",
+            "runner": "windows-latest"
         }
     }, {
         "build-types": ["clang32"],
         "matrix": {
             "packages": "base-devel git",
             "build-args": "--build-types clang32",
-            "name": "clang32"
+            "name": "clang32",
+            "runner": "windows-latest"
+        }
+    }, {
+        "build-types": ["clangarm64"],
+        "matrix": {
+            "packages": "base-devel git",
+            "build-args": "--build-types clangarm64",
+            "name": "clangarm64",
+            "runner": ["Windows", "ARM64"]
         }
     }, {
         "build-types": ["msys", "msys-src"],
         "matrix": {
             "packages": "base-devel msys2-devel git",
             "build-args": "--build-types msys,msys-src",
-            "name": "msys"
+            "name": "msys",
+            "runner": "windows-latest"
         }
     }
 ]


### PR DESCRIPTION
Workflow improvements to support a self-hosted runner on Windows ARM64.  The biggest issue is that the currently released versions of Windows on ARM64 do not support x64 emulation, only x86.

* The support for Windows ARM64 self-hosted runners is actions/runner#785
* I opened actions/runner#1185.  It would be nice to be able to check `${{ runner.arch }}` instead of seeing what the name starts with.
* Using my fork of setup-msys2 is probably a non-starter.  I have removed that hunk from the pull request, and replaced with a comment explaining that what's there won't actually work.