### PR TITLE
fix BUILD_ROOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         GITHUB_RUN_NAME: ${{ matrix.name }}
       run: |
         $env:PACKAGER='CI (msys2-autobuild/' + $env:GITHUB_SHA.Substring(0, 8) + '/' + $env:GITHUB_RUN_ID + ')'
-        $BUILD_ROOT='C:'
+        $BUILD_ROOT='C:\'
         $MSYS2_ROOT=(msys2 -c 'cygpath -w /')
         Get-PSDrive -PSProvider FileSystem
         python -u autobuild.py build ${{ matrix.build-args }} "$MSYS2_ROOT" "$BUILD_ROOT"


### PR DESCRIPTION
`C:` is the CWD on drive C, `C:\` is the root of drive C.


Seen on my arm64 self-hosted runner:
`Cloning into 'C:\runner\_work\msys2-autobuild\msys2-autobuild\M'...`