### PR TITLE
Updates for ARM64 running x64 now.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,8 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-        architecture: ${{ runner.arch == 'ARM64' && 'x86' || 'x64' }}
+        # Note that ARM64 prior to Win11 requires x86, but this will install x64
+        architecture: 'x64'
 
     - uses: actions/cache@v2
       with:
@@ -118,6 +119,7 @@ jobs:
         update: true
         install: ${{ matrix.packages }}
         location: 'D:\A'
+        release: ${{ runner.arch == 'ARM64' && 'false' || 'true' }}
 
     - name: Switch to the main mirror
       shell: msys2 {0}


### PR DESCRIPTION
Use x64 python everywhere.  Otherwise, it will try to find an ARM64
python, which Github doesn't offer in their metadata.

Pass `release: false` to setup-msys2 on ARM64.  My ARM64 runner has no D:,
and IO is slow enough to make setting up a fresh install on each run
prohibitive anyway.