### PR TITLE
break clang/libc++ cycle

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -92,8 +92,7 @@ class Config:
     OPTIONAL_DEPS: Dict[str, List[str]] = {
         "mingw-w64-headers-git": ["mingw-w64-winpthreads-git", "mingw-w64-tools-git"],
         "mingw-w64-crt-git": ["mingw-w64-winpthreads-git"],
-        "mingw-w64-librsvg": ["mingw-w64-gtk3"],
-        "mingw-w64-opencv": ["mingw-w64-ffmpeg"],
+        "mingw-w64-clang": ["mingw-w64-libc++"],
     }
     """XXX: In case of cycles we mark these deps as optional"""
 


### PR DESCRIPTION
before libc++ was split off from clang package, it was built after clang within the same PKGBUILD, so this order seems reasonably safe.

Also remove a couple of prior cycle breaks from before it was possible to break them manually in a run.  These packages are not related by the same source repo and release, like mingw-w64 and llvm-project are, so are less likely to consistently require a cycle break on every upstream update.