### PR TITLE
Use labels to restrict self-hosted runner selection.

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -1024,7 +1024,7 @@ def get_job_meta() -> List[Dict[str, Any]]:
                 "packages": "base-devel",
                 "build-args": "--build-types clangarm64",
                 "name": "clangarm64",
-                "runner": ["Windows", "ARM64"]
+                "runner": ["Windows", "ARM64", "autobuild"]
             }
         }, {
             "build-types": ["msys", "msys-src"],


### PR DESCRIPTION
For reasons of GitHub's API permissions, I prefer to use organization-scoped self-hosted runners rather than repository-scoped (organizations have a self-hosted runner permission, but repositories need repository admin to manage self-hosted runners).  This results in the same pool of runners being shared between msys2-autobuild and MINGW-packages (or other repositories in the msys2-arm organization).  I've found, though, that I prefer not to run MINGW-packages workflows on the same self-hosted runner as autobuild (since I don't trust it as much not to mess up the install somehow, and I'm dealing with persistent runners).  I currently enforce this by manually shutting down autobuild's workflow and the runner I use for autobuild before starting any MINGW-packages workflows.  This could be handled automatically by adding "autobuild" and "CI" labels to the runners, and adding those labels to the list of labels used to select the self-hosted runner for a job.

This commit does this for autobuild, restricting the runner selection to a runner which has Windows, ARM64, and now autobuild labels.

(This also seems like a situation that "runner groups" could have solved, but Github seems to only let paying organizations create those).