### PR TITLE
Pull in dependencies from staging recursively

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -508,8 +508,14 @@ SigLevel=Never
                             else:
                                 raise SystemExit(f"asset for {pattern} in {dep_type} not found")
 
+            if not to_add:
+                yield
+
             for dep_type, assets in to_add.items():
                 add_to_repo(repo_root, dep_type, assets)
+
+            # that might have pulled in new dependencies from staging
+            staging_dependencies(build_type, pkg, msys2_root, builddir)
 
             # in case they are already installed we need to upgrade
             run_cmd(msys2_root, ["pacman", "--noconfirm", "-Suy"])


### PR DESCRIPTION
I might be misunderstanding. But IIUC, `mingw-w64-clang-aarch64-ogre3d` is currently failing to build in staging because it depends on `mingw-w64-clang-aarch64-bullet` which has a new dependency `mingw-w64-clang-aarch64-openvr`. That dependency currently only exists in staging.
IIUC, it isn't pulled in in the first round of detecting dependencies because the `mingw-w64-clang-aarch64-bullet` in release doesn't have that dependency yet.
Try to handle that by pulling in dependencies recursively.

To be honest, Python isn't my strong suite. So, please check carefully if these changes make any sense.