### PR TITLE
Allow building qt6-static on clangarm64.

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -83,7 +83,7 @@ class Config:
     MANUAL_BUILD: List[Tuple[str, List[BuildType]]] = [
         ('mingw-w64-firebird-git', []),
         ('mingw-w64-qt5-static', ['mingw32', 'mingw64', 'ucrt64', 'clang32', 'clang64']),
-        ('mingw-w64-qt6-static', []),
+        ('mingw-w64-qt6-static', ['mingw32', 'mingw64', 'ucrt64', 'clang32', 'clang64']),
         ('mingw-w64-arm-none-eabi-gcc', []),
     ]
     """Packages that take too long to build, or can't be build and should be handled manually"""


### PR DESCRIPTION
The timeout on a self-hosted runner is much larger (72 hours, though there seemed to be a different limit related to the token hit before reaching that).

It might make sense to make sure it does in fact build before merging (just applying this in my fork was enough to get the build going).