### PR TITLE
CI: Remove enabling of clangarm64 in pacman.conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,6 @@ jobs:
       run: |
         echo 'Server = https://repo.msys2.org/mingw/$repo/' > /etc/pacman.d/mirrorlist.mingw
         echo 'Server = https://repo.msys2.org/msys/$arch/' > /etc/pacman.d/mirrorlist.msys
-        grep -qFx '[clangarm64]' /etc/pacman.conf || sed -i '/^# \[clangarm64\]/,/^$/ s|^# ||g' /etc/pacman.conf
         pacman-conf.exe
 
     - name: Update using the main mirror & Check install


### PR DESCRIPTION
It is now enabled by default so this is a no-op.

Had just cleaned up MINGW-packages workflow, and figured I'd make sure this was cleaned up too, even though it's not as much cruft in this repo.