### PR TITLE
Require a user confirmation for manual uploads

### DIFF
--- a/msys2_autobuild/config.py
+++ b/msys2_autobuild/config.py
@@ -27,11 +27,10 @@ def build_type_is_src(build_type: BuildType) -> bool:
 class Config:
 
     ALLOWED_UPLOADERS = [
-        ("User", "elieux"),
-        ("User", "Alexpux"),
-        ("User", "lazka"),
-        ("User", "jeremyd2019"),
-        ("Bot", "github-actions[bot]"),
+        "elieux",
+        "Alexpux",
+        "lazka",
+        "jeremyd2019",
     ]
     """Users that are allowed to upload assets. This is checked at download time"""
 

--- a/msys2_autobuild/config.py
+++ b/msys2_autobuild/config.py
@@ -28,7 +28,6 @@ class Config:
 
     ALLOWED_UPLOADERS = [
         "elieux",
-        "Alexpux",
         "lazka",
         "jeremyd2019",
     ]

--- a/msys2_autobuild/utils.py
+++ b/msys2_autobuild/utils.py
@@ -98,3 +98,19 @@ def parse_optional_deps(optional_deps: str) -> Dict[str, List[str]]:
 def apply_optional_deps(optional_deps: str) -> None:
     for dep, ignored in parse_optional_deps(optional_deps).items():
         Config.OPTIONAL_DEPS.setdefault(dep, []).extend(ignored)
+
+
+def ask_yes_no(prompt, default_no: bool = True):
+    """Ask a yes/no question via input() and return their answer."""
+
+    if default_no:
+        prompt += " [y/N] "
+    else:
+        prompt += " [Y/n] "
+
+    user_input = input(prompt).strip().lower()
+
+    if not user_input:
+        return False if default_no else True
+    else:
+        return user_input == 'y'


### PR DESCRIPTION
We currently allow some users to manually upload packages (in case
they take too long for CI, or to bootstrap things).

In case of an account takeover this would allow an attacker to upload/replace
files in staging. To reduce the risk a bit ask for confirmation when downloading
the manually uploaded files.

Also add a "--noconfirm" option so we can avoid the questions in the staging
download script.

Ideally we would require users to sign their files, but this helps a bit at least.