### PR TITLE
Partially revert "CI: Update actions/setup-python"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,8 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    # Reverted from v5 to v4 due to actions/setup-python#819
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
         cache: 'pip'


### PR DESCRIPTION
Due to actions/setup-python#819, it fails to install python on a Windows 11 (or presumably Server 2022) self-hosted runner, when a suitable version of python was not already installed.

Closes #85

This partially reverts commit d5779cd65dbe2e5dceb418c040b7d0d505372294.