### PR TITLE
CI: add a step which uninstalls all potentially left over packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,11 +174,15 @@ jobs:
       run: |
         # Remove everything not needed
         # XXX: this depends on marix.packages just being base+base-devel
-        TO_REMOVE=$(comm -23 <(pacman -Qq | sort) <((pactree -ul base | sed 's/[<>=].*//'; pactree -ul base-devel | sed 's/[<>=].*//') | sort -u))
+        KEEP=("base" "base-devel")
+        # https://github.com/msys2/msys2-autobuild/pull/87#issuecomment-2125614088
+        KEEP+=("mingw-w64-clang-aarch64-clang" "zip" "unzip" "vim" "etc-update" "psmisc")
+        pacman -S --noconfirm --needed "${KEEP[@]}"
+        TO_REMOVE=$(comm -23 <(pacman -Qq | sort) <(for tokeep in "${KEEP[@]}"; do pactree -ul "$tokeep" | sed 's/[<>=].*//'; done | sort -u))
         if [[ -n "$TO_REMOVE" ]]; then
             pacman --noconfirm -Rddn $TO_REMOVE
             # This shouldn't install anything, but just in case
-            pacman -S --noconfirm --needed ${{ matrix.packages }}
+            pacman -S --noconfirm --needed ${{ matrix.packages }} "${KEEP[@]}"
         fi
 
     - name: Process build queue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,19 @@ jobs:
         msys2 -c 'pacman --noconfirm -Suu'
         msys2 -c 'pacman -Qkq'
 
+    - name: Remove potentially left over packages
+      if: ${{ runner.arch == 'ARM64' }}
+      shell: msys2 {0}
+      run: |
+        # Remove everything not needed
+        # XXX: this depends on marix.packages just being base+base-devel
+        TO_REMOVE=$(comm -23 <(pacman -Qq | sort) <((pactree -ul base | sed 's/[<>=].*//'; pactree -ul base-devel | sed 's/[<>=].*//') | sort -u))
+        if [[ -n "$TO_REMOVE" ]]; then
+            pacman --noconfirm -Rddn $TO_REMOVE
+            # This shouldn't install anything, but just in case
+            pacman -S --noconfirm --needed ${{ matrix.packages }}
+        fi
+
     - name: Process build queue
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
         # XXX: this depends on marix.packages just being base+base-devel
         KEEP=("base" "base-devel")
         # https://github.com/msys2/msys2-autobuild/pull/87#issuecomment-2125614088
-        KEEP+=("mingw-w64-clang-aarch64-clang" "zip" "unzip" "vim" "etc-update" "psmisc")
+        KEEP+=($(pacman -Sgq mingw-w64-clang-aarch64-toolchain) "zip" "unzip" "vim" "etc-update" "psmisc")
         pacman -S --noconfirm --needed "${KEEP[@]}"
         TO_REMOVE=$(comm -23 <(pacman -Qq | sort) <(for tokeep in "${KEEP[@]}"; do pactree -ul "$tokeep" | sed 's/[<>=].*//'; done | sort -u))
         if [[ -n "$TO_REMOVE" ]]; then


### PR DESCRIPTION
In case a previous run has been aborted mid-run, there might still be packages installed. Make sure we get back to the minimal state again.