### PR TITLE
Revert "Partially revert "CI: Update actions/setup-python""

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,7 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    # Reverted from v5 to v4 due to actions/setup-python#819
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: 'pip'


### PR DESCRIPTION
The upstream issue (actions/setup-python#819) has (finally) been fixed.

This reverts commit 3e617554bbe6fc206a4032e86b0cc79aedad42e6.