### PR TITLE
queue: fix missing cycles with build-only deps of deps

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,7 +1,90 @@
 # type: ignore
 
 from msys2_autobuild.utils import parse_optional_deps
+from msys2_autobuild.queue import parse_buildqueue, get_cycles
 
 
 def test_parse_optional_deps():
     assert parse_optional_deps("a:b,c:d,a:x") == {'a': ['b', 'x'], 'c': ['d']}
+
+
+def test_get_cycles():
+    buildqueue = """
+[
+  {
+    "name": "c-ares",
+    "version": "1.34.2-1",
+    "version_repo": "1.33.1-1",
+    "repo_url": "https://github.com/msys2/MSYS2-packages",
+    "repo_path": "c-ares",
+    "source": true,
+    "builds": {
+      "msys": {
+        "packages": [
+          "libcares",
+          "libcares-devel"
+        ],
+        "depends": {
+          "msys": [
+            "libnghttp2",
+            "libuv"
+          ]
+        },
+        "new": false
+      }
+    }
+  },
+  {
+    "name": "nghttp2",
+    "version": "1.64.0-1",
+    "version_repo": "1.63.0-1",
+    "repo_url": "https://github.com/msys2/MSYS2-packages",
+    "repo_path": "nghttp2",
+    "source": true,
+    "builds": {
+      "msys": {
+        "packages": [
+          "libnghttp2",
+          "libnghttp2-devel",
+          "nghttp2"
+        ],
+        "depends": {
+          "msys": [
+            "libcares",
+            "libcares-devel"
+          ]
+        },
+        "new": false
+      }
+    }
+  },
+  {
+    "name": "libuv",
+    "version": "1.49.2-1",
+    "version_repo": "1.49.1-1",
+    "repo_url": "https://github.com/msys2/MSYS2-packages",
+    "repo_path": "libuv",
+    "source": true,
+    "builds": {
+      "msys": {
+        "packages": [
+          "libuv",
+          "libuv-devel"
+        ],
+        "depends": {
+          "msys": [
+            "libnghttp2"
+          ]
+        },
+        "new": false
+      }
+    }
+  }
+]"""
+
+    pkgs = parse_buildqueue(buildqueue)
+    cycles = get_cycles(pkgs)
+    assert len(cycles) == 3
+    assert (pkgs[0], pkgs[2]) in cycles
+    assert (pkgs[0], pkgs[1]) in cycles
+    assert (pkgs[2], pkgs[1]) in cycles


### PR DESCRIPTION
We only looked at the dependencies of a package that are needed for building, but for detecting build cycles we also have to look at all transitive deps.

Unless the dependency is already finished, then we can ignore its build deps, even if they are not finished yet.

The test shows such a case where things indirectly create a cycle via cmake.

Fixes #91