### PR TITLE
update package name in OPTIONAL_DEPS

### DIFF
--- a/msys2_autobuild/config.py
+++ b/msys2_autobuild/config.py
@@ -84,6 +84,6 @@ class Config:
     OPTIONAL_DEPS: Dict[str, List[str]] = {
         "mingw-w64-headers-git": ["mingw-w64-winpthreads-git", "mingw-w64-tools-git"],
         "mingw-w64-crt-git": ["mingw-w64-winpthreads-git"],
-        "mingw-w64-clang": ["mingw-w64-libc++"],
+        "mingw-w64-llvm": ["mingw-w64-libc++"],
     }
     """XXX: In case of cycles we mark these deps as optional"""


### PR DESCRIPTION
The pkgbase was renamed from mingw-w64-clang to mingw-w64-llvm, but this still had the old name, requiring manual specification of breaking the cycle with libc++