### PR TITLE
CI-hardening: set persist-credentials=false for all actions/checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
         echo "$CONTEXT"
 
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-python@v5
       with:
@@ -122,6 +124,8 @@ jobs:
         Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
 
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/maint.yml
+++ b/.github/workflows/maint.yml
@@ -39,6 +39,8 @@ jobs:
         echo "$CONTEXT"
 
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
To avoid writing the token to disk. It still gets exposed via env vars to various steps, but this removes the access from any steps before that.

As recommeded by the zizmor scanner