### PR TITLE
CI-hardening: escape the msys2-location output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
         GITHUB_RUN_NAME: ${{ matrix.name }}
+        MSYS2_ROOT: ${{ steps.msys2.outputs.msys2-location }}
       run: |
         $env:VCPKG_ROOT=''
         $BUILD_ROOT='C:\'
-        python -m msys2_autobuild build ${{ matrix.build-args }} '${{ steps.msys2.outputs.msys2-location }}' "$BUILD_ROOT"
+        python -m msys2_autobuild build ${{ matrix.build-args }} "$env:MSYS2_ROOT" "$BUILD_ROOT"


### PR DESCRIPTION
While that comes from our own action, so we can in theory trust it, escape it for good measure. Can't hurt and silences a warning.