### PR TITLE
CI-hardening: move permissions to the job level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,15 @@ on:
 env:
   PYTHONUNBUFFERED: 1
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
 
   schedule:
     runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
 
     concurrency: autobuild-maint
 
@@ -95,6 +97,9 @@ jobs:
   build:
     timeout-minutes: 4320
     needs: schedule
+
+    permissions:
+      contents: write
 
     concurrency: autobuild-build-${{ matrix.name }}
 

--- a/.github/workflows/maint.yml
+++ b/.github/workflows/maint.yml
@@ -19,8 +19,7 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency: autobuild-maint
 
@@ -28,6 +27,9 @@ jobs:
 
   schedule:
     runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
 
     steps:
 


### PR DESCRIPTION
Instead of giving all jobs write permissions, default to no permissions and enable them on a per-job basis.

This does not change anything for us, but avoids accidental write permissions if a new job gets added without considering that it inherits the top level permissions, even if it doesn't need them.

See https://woodruffw.github.io/zizmor/audits/#excessive-permissions