### PR TITLE
build: try removing junctions before calling git clean

### DIFF
--- a/msys2_autobuild/build.py
+++ b/msys2_autobuild/build.py
@@ -163,6 +163,15 @@ def reset_git_repo(path: PathLike):
 
     def clean():
         assert os.path.exists(path)
+
+        # Try to avoid git hanging in a junction loop, by removing them
+        # before running git clean/reset
+        # https://github.com/msys2/msys2-autobuild/issues/108#issuecomment-2776420879
+        try:
+            remove_junctions(path)
+        except OSError as e:
+            print("Removing junctions failed", e)
+
         check_call(["git", "clean", "-xfdf"], cwd=path)
         check_call(["git", "reset", "--hard", "HEAD"], cwd=path)
 


### PR DESCRIPTION
See https://github.com/msys2/msys2-autobuild/issues/108#issuecomment-2776420879

It looks like git can under some circumstances hang forever when trying to clean the checkout when there are junction loops. So try to remove them manually before calling git clean.

Fixes #108