### PR TITLE
Use native arm64 Python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,6 @@ jobs:
       id: python
       with:
         python-version: '3.13'
-        # Note that ARM64 prior to Win11 requires x86, but this will install x64
-        architecture: 'x64'
         # Avoid it setting CMake/pkg-config variables
         # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#environment-variables
         update-environment: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
   
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Missing various (all) wheels still:

* [x] pynacl
* [x] cffi
* [ ] charset_normalizer (nothing there yet, maybe not needed)
* [ ] mypy (nothing there yet)
* [x] cryptography (waiting on release, starting with 46.0.0)

Probably all not worth it, but we can track it here.