### PR TITLE
Partly remove hack to fetch the current job ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
-        GITHUB_RUN_NAME: ${{ matrix.name }}
+        # https://github.com/actions/runner/issues/324#issuecomment-3324382354
+        # https://github.com/actions/runner/pull/4053
+        JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
         MSYS2_ROOT: ${{ steps.msys2.outputs.msys2-location }}
       run: |
         $BUILD_ROOT=Join-Path (Split-Path $env:GITHUB_WORKSPACE -Qualifier) "\"

--- a/msys2_autobuild/gh.py
+++ b/msys2_autobuild/gh.py
@@ -98,20 +98,14 @@ def download_text_asset(asset: GitReleaseAsset, cache=False) -> str:
 
 
 def get_current_run_urls() -> dict[str, str] | None:
-    # The only connection we have is the job name, so this depends
-    # on unique job names in all workflows
-    if "GITHUB_SHA" in os.environ and "GITHUB_RUN_NAME" in os.environ:
-        sha = os.environ["GITHUB_SHA"]
-        run_name = os.environ["GITHUB_RUN_NAME"]
-        commit = get_current_repo().get_commit(sha)
-        check_runs = commit.get_check_runs(
-            check_name=run_name, status="in_progress", filter="latest")
-        for run in check_runs:
-            html = run.html_url + "?check_suite_focus=true"
-            raw = commit.html_url + "/checks/" + str(run.id) + "/logs"
-            return {"html": html, "raw": raw}
-        else:
-            raise Exception(f"No active job found for {run_name}")
+    if "JOB_CHECK_RUN_ID" in os.environ:
+        job_check_run_id = os.environ["JOB_CHECK_RUN_ID"]
+        repo = get_current_repo()
+        run = repo.get_check_run(int(job_check_run_id))
+        html = run.html_url + "?check_suite_focus=true"
+        commit = repo.get_commit(run.head_sha)
+        raw = commit.html_url + "/checks/" + str(run.id) + "/logs"
+        return {"html": html, "raw": raw}
     return None
 
 


### PR DESCRIPTION
GH runner now exposes a "job.check_run_id" in the template language, which we can use directly for the API to fetch information about the job currently in progress.

Previously we looked through all active jobs and matched them by name.

There is no env var for job.check_run_id, so we have to set the env var in the yaml file still.