### PR TITLE
Rework package upload process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         python -m msys2_autobuild show --optional-deps "$OPTIONAL_DEPS"
 
-  build:
+  supervise:
     timeout-minutes: 4320
     needs: schedule
 
@@ -104,6 +104,49 @@ jobs:
 
     permissions:
       contents: write
+
+    if: ${{ needs.schedule.outputs.build-plan != '[]' }}
+    runs-on: ubuntu-24.04
+    name: Supervise build and update status
+    steps:
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+        cache-dependency-path: 'requirements.txt'
+
+    - name: Install deps
+      env:
+        PIP_DISABLE_PIP_VERSION_CHECK: 1
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        python -m pip install -r requirements.txt
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+
+    - name: Supervise build
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
+        JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
+      run: |
+        python -m msys2_autobuild supervise
+
+  build:
+    timeout-minutes: 4320
+    needs: schedule
+
+    environment:
+      name: build
+      deployment: false
+
+    permissions:
+      contents: read
 
     concurrency: autobuild-build-${{ matrix.name }}
 
@@ -186,7 +229,6 @@ jobs:
 
     - name: Process build queue
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
         ACTIONS_RUNTIME_TOKEN: ${{ steps.vars.outputs.ACTIONS_RUNTIME_TOKEN }}
         ACTIONS_RESULTS_URL: ${{ steps.vars.outputs.ACTIONS_RESULTS_URL }}
@@ -197,10 +239,3 @@ jobs:
       run: |
         $BUILD_ROOT=Join-Path (Split-Path $env:GITHUB_WORKSPACE -Qualifier) "\"
         python -m msys2_autobuild build ${{ matrix.build-args }} "$env:MSYS2_ROOT" "$BUILD_ROOT"
-
-    - name: Update build status
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
-      run: |
-        python -m msys2_autobuild update-status

--- a/msys2_autobuild/build.py
+++ b/msys2_autobuild/build.py
@@ -19,8 +19,8 @@ from github.GitReleaseAsset import GitReleaseAsset
 
 from .config import ArchType, BuildType, Config
 from .gh import (CachedAssets, download_asset, get_asset_filename,
-                 get_current_run_urls, get_release, get_repo_for_build_type, upload_asset,
-                 wait_for_api_limit_reset, is_running_in_gha, upload_artifact)
+                 get_current_run_urls, is_running_in_gha, upload_artifact,
+                 get_workflow_run_id, get_job_check_run_id)
 from .queue import Package
 from .utils import SCRIPT_DIR, PathLike
 
@@ -49,11 +49,12 @@ def pure_posix_path_to_uri(path: PurePath) -> str:
 def get_packager(build_type: BuildType) -> str:
     """Returns a string to use as the PACKAGER for makepkg, which identifies the
     CI run that built the package"""
-    environ = os.environ
     packager_ref = Config.RUNNER_CONFIG[build_type]["repo"]
-    if "GITHUB_RUN_ID" in environ and "JOB_CHECK_RUN_ID" in environ:
-        packager_ref += "/actions/runs/" + quote(environ["GITHUB_RUN_ID"], safe="") + \
-            "/job/" + quote(environ["JOB_CHECK_RUN_ID"], safe="")
+    workflow_run_id = get_workflow_run_id()
+    job_check_run_id = get_job_check_run_id()
+    if workflow_run_id is not None and job_check_run_id is not None:
+        packager_ref += "/actions/runs/" + quote(str(workflow_run_id), safe="") + \
+            "/job/" + quote(str(job_check_run_id), safe="")
     return f"CI ({packager_ref})"
 
 
@@ -346,8 +347,6 @@ def build_package(build_type: BuildType, pkg: Package, msys2_root: PathLike, bui
     repo_dir = os.path.join(builddir, repo_name)
     to_upload: list[str] = []
 
-    repo = get_repo_for_build_type(build_type)
-
     with fresh_git_repo(pkg['repo_url'], repo_dir):
         orig_pkg_dir = os.path.join(repo_dir, pkg['repo_path'])
         # Rename it to get a shorter overall build path
@@ -429,23 +428,16 @@ def build_package(build_type: BuildType, pkg: Package, msys2_root: PathLike, bui
                     to_upload.extend([os.path.join(pkg_dir, e) for e in found])
 
             except (subprocess.CalledProcessError, BuildError) as e:
-                wait_for_api_limit_reset()
-                release = get_release(repo, "staging-failed")
-                run_urls = get_current_run_urls()
-                failed_data = {}
-                if run_urls is not None:
-                    failed_data["urls"] = run_urls
-                content = json.dumps(failed_data).encode()
-                upload_asset(release, pkg.get_failed_name(build_type), text=True, content=content)
+                if is_running_in_gha():
+                    run_urls = get_current_run_urls()
+                    failed_data = {}
+                    if run_urls is not None:
+                        failed_data["urls"] = run_urls
+                    content = json.dumps(failed_data).encode()
+                    upload_artifact(pkg.get_failed_name(build_type), content=content)
 
                 raise BuildError(e)
             else:
-                wait_for_api_limit_reset()
-                release = get_release(repo, "staging-" + build_type)
-                for path in to_upload:
-                    upload_asset(release, path)
-
-                # XXX: this is a test to see if uploading artifacts instead of assets works for our use case
                 if is_running_in_gha():
                     for path in to_upload:
                         upload_artifact(path)

--- a/msys2_autobuild/cmd_build.py
+++ b/msys2_autobuild/cmd_build.py
@@ -8,8 +8,7 @@ from typing import Any, Literal
 from .build import BuildError, build_package, run_cmd
 from .config import BuildType, Config
 from .gh import wait_for_api_limit_reset
-from .queue import (Package, PackageStatus, get_buildqueue_with_status,
-                    update_status)
+from .queue import (Package, PackageStatus, get_buildqueue_with_status)
 from .utils import apply_optional_deps, gha_group
 
 BuildFrom = Literal["start", "middle", "end"]
@@ -17,7 +16,8 @@ BuildFrom = Literal["start", "middle", "end"]
 
 def get_package_to_build(
         pkgs: list[Package], build_types: list[BuildType] | None,
-        build_from: BuildFrom) -> tuple[Package, BuildType] | None:
+        build_from: BuildFrom,
+        skip: list[tuple[Package, BuildType]] = []) -> tuple[Package, BuildType] | None:
 
     can_build = []
     for pkg in pkgs:
@@ -26,6 +26,8 @@ def get_package_to_build(
                 continue
             if pkg.get_status(build_type) == PackageStatus.WAITING_FOR_BUILD:
                 can_build.append((pkg, build_type))
+
+    can_build = [item for item in can_build if item not in skip]
 
     if not can_build:
         return None
@@ -68,19 +70,20 @@ def run_build(args: Any) -> None:
 
     print(f"Building {build_types} starting from {args.build_from}")
 
+    skip = []
     while True:
         wait_for_api_limit_reset()
 
-        pkgs = get_buildqueue_with_status(full_details=True)
-        update_status(pkgs)
+        pkgs = get_buildqueue_with_status()
 
         if (time.monotonic() - start_time) >= Config.SOFT_JOB_TIMEOUT:
             print("timeout reached")
             break
 
-        todo = get_package_to_build(pkgs, build_types, args.build_from)
+        todo = get_package_to_build(pkgs, build_types, args.build_from, skip)
         if not todo:
             break
+        skip.append(todo)
         pkg, build_type = todo
 
         try:

--- a/msys2_autobuild/cmd_supervise.py
+++ b/msys2_autobuild/cmd_supervise.py
@@ -1,0 +1,121 @@
+from typing import Any
+import fnmatch
+import time
+import traceback
+
+from github.Artifact import Artifact
+
+from .gh import get_current_repo, get_artifact_filename, get_release, \
+    download_artifact, upload_asset, make_writable, wait_for_api_limit_reset, \
+    get_workflow_run_id, get_job_check_run_id
+from .queue import get_buildqueue_with_status, update_status, get_build_jobs_status
+
+
+def supervise(args: Any) -> None:
+    dry_run = args.dry_run
+    repo = get_current_repo()
+
+    if args.workflow_run_id is None:
+        env_run_id = get_workflow_run_id()
+        if env_run_id is None:
+            print("Error: --workflow-run-id not specified and GITHUB_RUN_ID env var not set")
+            return
+        workflow_run_id = env_run_id
+    else:
+        workflow_run_id = args.workflow_run_id
+
+    def deploy_artifacts(artifacts: list[Artifact]) -> bool:
+        """Upload the artifacts to the releases and delete them from the workflow run.
+        Returns True if any artifacts were uploaded."""
+
+        if not artifacts:
+            return False
+
+        # For each release, find the matching artifacts
+        artifacts_map = {get_artifact_filename(artifact): artifact for artifact in artifacts}
+        pkgs = get_buildqueue_with_status()
+        release_map: dict[str, list[Artifact]] = {}
+        for pkg in pkgs:
+            for build_type in pkg.get_build_types():
+                matches = []
+                for pattern in pkg.get_build_patterns(build_type):
+                    matches.extend(fnmatch.filter(artifacts_map.keys(), pattern))
+                release_map.setdefault(
+                    'staging-' + build_type, []).extend([artifacts_map[match] for match in matches])
+
+                matches = []
+                for pattern in pkg.get_failed_patterns(build_type):
+                    matches.extend(fnmatch.filter(artifacts_map.keys(), pattern))
+                release_map.setdefault(
+                    'staging-failed', []).extend([artifacts_map[match] for match in matches])
+
+        # Upload the artifacts to the releases and delete them from the workflow run
+        changed = False
+        for release_name, artifacts in release_map.items():
+            release = get_release(repo, release_name)
+            for artifact in artifacts:
+                changed = True
+                data = download_artifact(artifact)
+                filename = get_artifact_filename(artifact)
+                print(f"Uploading {filename} to release {release_name}")
+                if not dry_run:
+                    upload_asset(release, filename, content=data)
+                print(f"Deleting artifact {filename}")
+                if not dry_run:
+                    with make_writable(artifact):
+                        artifact.delete()
+
+        return changed
+
+    run = repo.get_workflow_run(workflow_run_id)
+    jobs_status = []
+    while True:
+        wait_for_api_limit_reset()
+
+        try:
+            artifacts = list(run.get_artifacts())
+            was_deployed = deploy_artifacts(artifacts)
+
+            jobs = list(run.jobs())
+            new_jobs_status = get_build_jobs_status(jobs)
+            status_changed = False
+            if new_jobs_status != jobs_status:
+                jobs_status = new_jobs_status
+                status_changed = True
+
+            if was_deployed or status_changed:
+                print("Updating build queue status...")
+                pkgs = get_buildqueue_with_status(full_details=True)
+                if not dry_run:
+                    update_status(pkgs)
+        except Exception:
+            traceback.print_exc()
+            print("Error while supervising, will retry in 5 minutes...")
+            time.sleep(300)
+
+        is_any_job_running = False
+        for job in run.jobs():
+            if job.id == get_job_check_run_id():
+                continue
+            if job.status not in ("completed", "failure"):
+                is_any_job_running = True
+                break
+
+        if is_any_job_running:
+            print("Build jobs are still running, checking again in 30 seconds...")
+            time.sleep(30)
+        else:
+            print("Build jobs are completed, stopping supervision.")
+            break
+
+
+def add_parser(subparsers: Any) -> None:
+    sub = subparsers.add_parser(
+        "supervise", help="Supervise build jobs", allow_abbrev=False)
+    sub.add_argument(
+        "--workflow-run-id",
+        type=int,
+        help="Workflow run to supervise, if not specified uses GITHUB_RUN_ID env var")
+    sub.add_argument(
+        "--dry-run", action="store_true", help="Only show what is going to be uploaded")
+    sub.set_defaults(func=supervise)

--- a/msys2_autobuild/gh.py
+++ b/msys2_autobuild/gh.py
@@ -20,6 +20,7 @@ from github.GithubException import GithubException, UnknownObjectException
 from github.GithubObject import GithubObject
 from github.GitRelease import GitRelease
 from github.GitReleaseAsset import GitReleaseAsset
+from github.Artifact import Artifact
 from github.Repository import Repository
 from gha_artifact_client import ArtifactClientApi
 
@@ -99,11 +100,23 @@ def download_text_asset(asset: GitReleaseAsset, cache=False) -> str:
         return r.text
 
 
+def get_workflow_run_id() -> int|None:
+    if "GITHUB_RUN_ID" not in os.environ:
+        return None
+    return int(os.environ["GITHUB_RUN_ID"])
+
+
+def get_job_check_run_id() -> int|None:
+    if "JOB_CHECK_RUN_ID" not in os.environ:
+        return None
+    return int(os.environ["JOB_CHECK_RUN_ID"])
+
+
 def get_current_run_urls() -> dict[str, str] | None:
-    if "JOB_CHECK_RUN_ID" in os.environ:
-        job_check_run_id = os.environ["JOB_CHECK_RUN_ID"]
+    job_check_run_id = get_job_check_run_id()
+    if job_check_run_id is not None:
         repo = get_current_repo()
-        run = repo.get_check_run(int(job_check_run_id))
+        run = repo.get_check_run(job_check_run_id)
         html = run.html_url + "?check_suite_focus=true"
         commit = repo.get_commit(run.head_sha)
         raw = commit.html_url + "/checks/" + str(run.id) + "/logs"
@@ -139,6 +152,28 @@ def get_asset_mtime_ns(asset: GitReleaseAsset) -> int:
     """Returns the mtime of an asset in nanoseconds"""
 
     return int(asset.updated_at.timestamp() * (1000 ** 3))
+
+
+def download_artifact(artifact: Artifact) -> bytes:
+    """Downloads the artifact and returns its content as bytes"""
+
+    assert not artifact.expired
+
+    # "You must have the actions scope to download artifacts"
+    with make_writable(artifact):
+        requester = artifact.requester
+    status, responseHeaders, output = requester.requestBlob("GET",
+        artifact.archive_download_url, headers={"Accept": "application/vnd.github+json"})
+    assert status == 302 and output == ""
+
+    # Now download the signed URL and verify the digest
+    session = get_requests_session(nocache=True)
+    with session.get(responseHeaders["location"], timeout=REQUESTS_TIMEOUT) as r:
+        r.raise_for_status()
+        content = r.content
+        with verify_artifact_digest(artifact) as hash:
+            hash.update(content)
+        return content
 
 
 def download_asset(asset: GitReleaseAsset, target_path: str,
@@ -195,6 +230,10 @@ def get_asset_filename(asset: GitReleaseAsset) -> str:
     return asset.label
 
 
+def get_artifact_filename(artifact: Artifact) -> str:
+    return decode_filename(artifact.name.rsplit(".", 1)[0])
+
+
 @contextmanager
 def verify_asset_digest(asset: GitReleaseAsset) -> Generator[Any, None, None]:
     digest = asset.digest
@@ -209,6 +248,20 @@ def verify_asset_digest(asset: GitReleaseAsset) -> Generator[Any, None, None]:
         hexdigest = h.hexdigest().lower()
         if h.hexdigest() != value:
             raise Exception(f"Digest mismatch for asset {get_asset_filename(asset)}: "
+                            f"got {hexdigest}, expected {value}")
+
+@contextmanager
+def verify_artifact_digest(artifact: Artifact) -> Generator[Any, None, None]:
+    digest = artifact.digest
+    type_, value = digest.split(":", 1)
+    value = value.lower()
+    h = hashlib.new(type_)
+    try:
+        yield h
+    finally:
+        hexdigest = h.hexdigest().lower()
+        if h.hexdigest() != value:
+            raise Exception(f"Digest mismatch for asset {get_artifact_filename(artifact)}: "
                             f"got {hexdigest}, expected {value}")
 
 
@@ -256,7 +309,8 @@ def can_upload_artifacts() -> bool:
     return "ACTIONS_RUNTIME_TOKEN" in os.environ and "ACTIONS_RESULTS_URL" in os.environ
 
 
-def upload_artifact(path: PathLike, text: bool = False, retention_hours: int = 7) -> None:
+def upload_artifact(path: PathLike, text: bool = False, retention_hours: int = 7,
+                    content: bytes | None = None) -> None:
     assert can_upload_artifacts()
 
     path = Path(path)
@@ -264,7 +318,12 @@ def upload_artifact(path: PathLike, text: bool = False, retention_hours: int = 7
     asset_name = get_upload_safe_name(basename, text)
 
     client = ArtifactClientApi()
-    result = client.upload_artifact(path, name=asset_name, expires_in=3600 * retention_hours)
+    if content is None:
+        result = client.upload_artifact(
+            path, name=asset_name, expires_in=3600 * retention_hours)
+    else:
+        result = client.upload_artifact_bytes(
+            content, name=asset_name, expires_in=3600 * retention_hours)
     print(f"Uploaded {asset_name} as {result.id}")
 
 

--- a/msys2_autobuild/main.py
+++ b/msys2_autobuild/main.py
@@ -4,7 +4,7 @@ import logging
 
 from . import (cmd_build, cmd_clean_assets, cmd_clear_failed, cmd_fetch_assets,
                cmd_show_build, cmd_update_status, cmd_upload_assets,
-               cmd_write_build_plan, cmd_show_status)
+               cmd_write_build_plan, cmd_show_status, cmd_supervise)
 from .utils import install_requests_cache
 
 
@@ -27,6 +27,7 @@ def main(argv: list[str]) -> None:
     cmd_upload_assets.add_parser(subparsers)
     cmd_clear_failed.add_parser(subparsers)
     cmd_clean_assets.add_parser(subparsers)
+    cmd_supervise.add_parser(subparsers)
 
     args = parser.parse_args(argv[1:])
     level_map = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}

--- a/msys2_autobuild/queue.py
+++ b/msys2_autobuild/queue.py
@@ -106,6 +106,9 @@ class Package(dict):
             assert 0
         return patterns
 
+    def get_failed_patterns(self, build_type: BuildType) -> list[str]:
+        return [self.get_failed_name(build_type)]
+
     def get_failed_name(self, build_type: BuildType) -> str:
         return f"{build_type}-{self['name']}-{self['version']}.failed"
 
@@ -391,42 +394,47 @@ def get_buildqueue_with_status(full_details: bool = False) -> list[Package]:
     return pkgs
 
 
+def get_build_jobs_status(jobs: list[WorkflowJob]) -> list[dict[str, str]]:
+    jobs_status = []
+
+    def is_building(job: WorkflowJob) -> bool:
+        if job.status != "in_progress":
+            return False
+        if job.name == "schedule" or job.name == "supervise":
+            return False
+        for step in job.steps:
+            if step.name == "Process build queue":
+                return step.status != "completed"
+        else:
+            if len(job.steps) <= 1:
+                # When a job starts up it returns only the initial "Set up job" step
+                # for a short time
+                return False
+            raise Exception("No 'Process build queue' step found")
+
+    for job in jobs:
+        if is_building(job):
+            jobs_status.append({
+                "name": job.name,
+                "html_url": job.html_url,
+                "started_at": job.started_at.isoformat()
+            })
+    return sorted(jobs_status, key=lambda j: (j["started_at"], j["html_url"]))
+
+
 def get_status(pkgs: list[Package]) -> dict[str, Any]:
     status_object: dict[str, Any] = {}
 
     # All currently running jobs
-    all_jobs = []
     repo = get_current_repo()
     workflow_runs_in_progress = repo.get_workflow_runs(status="in_progress")
     workflow_runs_pending = repo.get_workflow_runs(status="pending")
+    build_jobs = []
     for run in itertools.chain(workflow_runs_in_progress, workflow_runs_pending):
         if run.name != "build":
             continue
-        jobs = run.jobs("all")
-
-        def is_building(job: WorkflowJob) -> bool:
-            if job.status != "in_progress":
-                return False
-            if job.name == "schedule":
-                return False
-            for step in job.steps:
-                if step.name == "Process build queue":
-                    return step.status != "completed"
-            else:
-                if len(job.steps) <= 1:
-                    # When a job starts up it returns only the initial "Set up job" step
-                    # for a short time
-                    return False
-                raise Exception("No 'Process build queue' step found")
-
-        for job in jobs:
-            if is_building(job):
-                all_jobs.append({
-                    "name": job.name,
-                    "html_url": job.html_url,
-                    "started_at": job.started_at.isoformat()
-                })
-    status_object["jobs"] = sorted(all_jobs, key=lambda j: (j["started_at"], j["html_url"]))
+        build_jobs.extend(run.jobs("all"))
+    status_object["jobs"] = get_build_jobs_status(build_jobs)
 
     packages = []
     for pkg in pkgs:


### PR DESCRIPTION
The goal is to have fewer permissions in the build job.

In build we now upload workflow artifacts instead of uploading release assets. We never try to build the same package twice since there is now a delay in when we see it as a release asset.

There is a new "supervise" job which collects the workflow artifacts from all build jobs and uploads them as release assets. In addition it updates the queue status if something has changed.