### PR TITLE
Move builds away from the main branch

### DIFF
--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -1,0 +1,117 @@
+name: 'build-jobs'
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-plan:
+        default: '[]'
+        required: true
+        type: string
+
+env:
+  PYTHONUNBUFFERED: 1
+
+permissions: {}
+
+jobs:
+  build:
+    timeout-minutes: 4320
+
+    environment:
+      name: build-jobs
+      deployment: false
+
+    permissions:
+      contents: read
+
+    concurrency: autobuild-build-jobs-${{ matrix.name }}
+
+    if: ${{ inputs.build-plan != '[]' && github.ref == 'refs/heads/build-branch' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.build-plan) }}
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+
+    - name: Configure Pagefile
+      if: ${{ matrix.hosted }}
+      # https://github.com/al-cheb/configure-pagefile-action/issues/16
+      continue-on-error: true
+      uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
+      with:
+        minimum-size: 4GB
+        maximum-size: 16GB
+        disk-root: "C:"
+
+    - name: Runner details
+      run: |
+        Get-PSDrive -PSProvider FileSystem
+        Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      id: python
+      with:
+        python-version: '3.14'
+        # Avoid it setting CMake/pkg-config variables
+        # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#environment-variables
+        update-environment: false
+
+    # Work around https://github.com/actions/setup-python/issues/1050
+    - name: Cache pip dependencies
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-pip-
+
+    - name: Install deps
+      env:
+        PIP_DISABLE_PIP_VERSION_CHECK: 1
+        PYTHON_PATH: ${{ steps.python.outputs.python-path }}
+      run: |
+        & "$env:PYTHON_PATH" -m venv .venv
+        .\.venv\Scripts\activate
+        python -m pip install -r requirements.txt
+        echo "$env:VIRTUAL_ENV\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    # Note that ARM64 prior to Win11 requires x86 msys, but this will install x64
+    - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
+      env:
+        __SETUP_MSYS2_USE_MAIN_MIRROR_ONLY: 'true'
+      id: msys2
+      with:
+        msystem: MSYS
+        update: true
+        install: ${{ matrix.packages }}
+        location: '\M'
+        release: ${{ matrix.hosted }}
+        cache: ${{ matrix.hosted }}
+
+    - name: Get artifact credentials
+      id: vars
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          core.setOutput('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          core.setOutput('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
+
+    - name: Process build queue
+      env:
+        GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
+        ACTIONS_RUNTIME_TOKEN: ${{ steps.vars.outputs.ACTIONS_RUNTIME_TOKEN }}
+        ACTIONS_RESULTS_URL: ${{ steps.vars.outputs.ACTIONS_RESULTS_URL }}
+        # https://github.com/actions/runner/issues/324#issuecomment-3324382354
+        # https://github.com/actions/runner/pull/4053
+        JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
+        MSYS2_ROOT: ${{ steps.msys2.outputs.msys2-location }}
+      run: |
+        $BUILD_ROOT=Join-Path (Split-Path $env:GITHUB_WORKSPACE -Qualifier) "\"
+        python -m msys2_autobuild build ${{ matrix.build-args }} "$env:MSYS2_ROOT" "$BUILD_ROOT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,16 @@ jobs:
       run: |
         python -m msys2_autobuild show --optional-deps "$OPTIONAL_DEPS"
 
+    - name: Dispatch build jobs
+      if: steps.check.outputs.build-plan != '[]'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
+      run: |
+        python -m msys2_autobuild exec-build-plan --target-branch "build-branch" build_plan.json exec_result.json
+        execResult="$(cat exec_result.json)"
+        echo "exec-result=$execResult" >> $GITHUB_OUTPUT
+
   supervise:
     timeout-minutes: 4320
     needs: schedule
@@ -139,108 +149,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
         JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
+        TARGET_WORKFLOW_RUN_ID: ${{ fromJson(needs.schedule.outputs.exec-result).run_id }}
       run: |
-        python -m msys2_autobuild supervise
-
-  build:
-    timeout-minutes: 4320
-    needs: schedule
-
-    environment:
-      name: build
-      deployment: false
-
-    permissions:
-      contents: read
-
-    concurrency: autobuild-build-${{ matrix.name }}
-
-    if: ${{ needs.schedule.outputs.build-plan != '[]' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.schedule.outputs.build-plan) }}
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-
-    - name: Configure Pagefile
-      if: ${{ matrix.hosted }}
-      # https://github.com/al-cheb/configure-pagefile-action/issues/16
-      continue-on-error: true
-      uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
-      with:
-        minimum-size: 4GB
-        maximum-size: 16GB
-        disk-root: "C:"
-
-    - name: Runner details
-      run: |
-        Get-PSDrive -PSProvider FileSystem
-        Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
-
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      id: python
-      with:
-        python-version: '3.14'
-        # Avoid it setting CMake/pkg-config variables
-        # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#environment-variables
-        update-environment: false
-
-    # Work around https://github.com/actions/setup-python/issues/1050
-    - name: Cache pip dependencies
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-pip-
-
-    - name: Install deps
-      env:
-        PIP_DISABLE_PIP_VERSION_CHECK: 1
-        PYTHON_PATH: ${{ steps.python.outputs.python-path }}
-      run: |
-        & "$env:PYTHON_PATH" -m venv .venv
-        .\.venv\Scripts\activate
-        python -m pip install -r requirements.txt
-        echo "$env:VIRTUAL_ENV\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-    # Note that ARM64 prior to Win11 requires x86 msys, but this will install x64
-    - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
-      env:
-        __SETUP_MSYS2_USE_MAIN_MIRROR_ONLY: 'true'
-      id: msys2
-      with:
-        msystem: MSYS
-        update: true
-        install: ${{ matrix.packages }}
-        location: '\M'
-        release: ${{ matrix.hosted }}
-        cache: ${{ matrix.hosted }}
-
-    - name: Get artifact credentials
-      id: vars
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-      with:
-        script: |
-          core.setOutput('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
-          core.setOutput('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
-
-    - name: Process build queue
-      env:
-        GITHUB_TOKEN_READONLY: ${{ secrets.GITHUBTOKENREADONLY }}
-        ACTIONS_RUNTIME_TOKEN: ${{ steps.vars.outputs.ACTIONS_RUNTIME_TOKEN }}
-        ACTIONS_RESULTS_URL: ${{ steps.vars.outputs.ACTIONS_RESULTS_URL }}
-        # https://github.com/actions/runner/issues/324#issuecomment-3324382354
-        # https://github.com/actions/runner/pull/4053
-        JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
-        MSYS2_ROOT: ${{ steps.msys2.outputs.msys2-location }}
-      run: |
-        $BUILD_ROOT=Join-Path (Split-Path $env:GITHUB_WORKSPACE -Qualifier) "\"
-        python -m msys2_autobuild build ${{ matrix.build-args }} "$env:MSYS2_ROOT" "$BUILD_ROOT"
+        python -m msys2_autobuild supervise --workflow-run-id "$TARGET_WORKFLOW_RUN_ID"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ uv tool install git+https://github.com/msys2/msys2-autobuild
 ```console
 $ msys2-autobuild --help
 usage: msys2-autobuild [-h] [-v]
-                       {build,show,write-build-plan,update-status,show-status,fetch-assets,upload-assets,clear-failed,clean-assets,supervise} ...
+    {build,show,write-build-plan,update-status,show-status,fetch-assets,upload-assets,clear-failed,clean-assets,supervise,exec-build-plan} ...
 
 Build packages
 
@@ -32,7 +32,7 @@ options:
   -v, --verbose         Increase verbosity (can be used multiple times)
 
 subcommands:
-  {build,show,write-build-plan,update-status,show-status,fetch-assets,upload-assets,clear-failed,clean-assets,supervise}
+  {build,show,write-build-plan,update-status,show-status,fetch-assets,upload-assets,clear-failed,clean-assets,supervise,exec-build-plan}
     build               Build all packages
     show                Show all packages to be built
     write-build-plan    Write a GHA build matrix setup
@@ -43,6 +43,7 @@ subcommands:
     clear-failed        Clear the failed state for packages
     clean-assets        Clean up GHA assets
     supervise           Supervise build jobs
+    exec-build-plan     Execute the build plan
 ```
 
 ## Configuration

--- a/msys2_autobuild/cmd_exec_build_plan.py
+++ b/msys2_autobuild/cmd_exec_build_plan.py
@@ -1,0 +1,32 @@
+import json
+from typing import Any
+
+from .gh import get_current_repo, create_dispatch
+
+
+def exec_build_plan(args: Any) -> None:
+    target_file = args.target_file
+    build_plan_file = args.build_plan_file
+    branch = args.branch
+
+    with open(build_plan_file, "rb") as h:
+        build_plan = h.read().decode()
+
+    repo = get_current_repo()
+    workflow = repo.get_workflow("build-jobs.yml")
+    workflow_run = create_dispatch(workflow, branch, inputs={"build_plan": build_plan})
+
+    with open(target_file, "wb") as h:
+        h.write(json.dumps({
+            "run_id": workflow_run.id,
+        }).encode())
+
+
+def add_parser(subparsers: Any) -> None:
+    sub = subparsers.add_parser(
+        "exec-build-plan", help="Execute the build plan", allow_abbrev=False)
+    sub.add_argument(
+        "--target-branch", type=str, help="Branch to build in", required=True)
+    sub.add_argument("build_plan_file")
+    sub.add_argument("target_file")
+    sub.set_defaults(func=exec_build_plan)

--- a/msys2_autobuild/cmd_supervise.py
+++ b/msys2_autobuild/cmd_supervise.py
@@ -6,23 +6,14 @@ import traceback
 from github.Artifact import Artifact
 
 from .gh import get_current_repo, get_artifact_filename, get_release, \
-    download_artifact, upload_asset, make_writable, wait_for_api_limit_reset, \
-    get_workflow_run_id, get_job_check_run_id
+    download_artifact, upload_asset, make_writable, wait_for_api_limit_reset
 from .queue import get_buildqueue_with_status, update_status, get_build_jobs_status
 
 
 def supervise(args: Any) -> None:
     dry_run = args.dry_run
     repo = get_current_repo()
-
-    if args.workflow_run_id is None:
-        env_run_id = get_workflow_run_id()
-        if env_run_id is None:
-            print("Error: --workflow-run-id not specified and GITHUB_RUN_ID env var not set")
-            return
-        workflow_run_id = env_run_id
-    else:
-        workflow_run_id = args.workflow_run_id
+    workflow_run_id = args.workflow_run_id
 
     def deploy_artifacts(artifacts: list[Artifact]) -> bool:
         """Upload the artifacts to the releases and delete them from the workflow run.
@@ -85,8 +76,6 @@ def supervise(args: Any) -> None:
 
         is_any_job_running = False
         for job in run.jobs():
-            if job.id == get_job_check_run_id():
-                continue
             if job.status not in ("completed", "failure"):
                 is_any_job_running = True
                 break
@@ -126,7 +115,8 @@ def add_parser(subparsers: Any) -> None:
     sub.add_argument(
         "--workflow-run-id",
         type=int,
-        help="Workflow run to supervise, if not specified uses GITHUB_RUN_ID env var")
+        help="Workflow run to supervise",
+        required=True)
     sub.add_argument(
         "--dry-run", action="store_true", help="Only show what is going to be uploaded")
     sub.set_defaults(func=supervise)

--- a/msys2_autobuild/main.py
+++ b/msys2_autobuild/main.py
@@ -4,7 +4,8 @@ import logging
 
 from . import (cmd_build, cmd_clean_assets, cmd_clear_failed, cmd_fetch_assets,
                cmd_show_build, cmd_update_status, cmd_upload_assets,
-               cmd_write_build_plan, cmd_show_status, cmd_supervise)
+               cmd_write_build_plan, cmd_show_status, cmd_supervise,
+               cmd_exec_build_plan)
 from .utils import install_requests_cache
 
 
@@ -28,6 +29,7 @@ def main(argv: list[str]) -> None:
     cmd_clear_failed.add_parser(subparsers)
     cmd_clean_assets.add_parser(subparsers)
     cmd_supervise.add_parser(subparsers)
+    cmd_exec_build_plan.add_parser(subparsers)
 
     args = parser.parse_args(argv[1:])
     level_map = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}

--- a/msys2_autobuild/queue.py
+++ b/msys2_autobuild/queue.py
@@ -404,8 +404,6 @@ def get_build_jobs_status(jobs: list[WorkflowJob]) -> list[dict[str, str]]:
     def is_building(job: WorkflowJob) -> bool:
         if job.status != "in_progress":
             return False
-        if job.name == "schedule" or job.name == "supervise":
-            return False
         for step in job.steps:
             if step.name == "Process build queue":
                 return step.status != "completed"
@@ -431,12 +429,11 @@ def get_status(pkgs: list[Package]) -> dict[str, Any]:
 
     # All currently running jobs
     repo = get_current_repo()
-    workflow_runs_in_progress = repo.get_workflow_runs(status="in_progress")
-    workflow_runs_pending = repo.get_workflow_runs(status="pending")
+    workflow = repo.get_workflow("build-jobs.yml")
+    workflow_runs_in_progress = workflow.get_runs(status="in_progress")
+    workflow_runs_pending = workflow.get_runs(status="pending")
     build_jobs = []
     for run in itertools.chain(workflow_runs_in_progress, workflow_runs_pending):
-        if run.name != "build":
-            continue
         build_jobs.extend(run.jobs("all"))
     status_object["jobs"] = get_build_jobs_status(build_jobs)
 


### PR DESCRIPTION
Instead of running the builds on the main branch, run them on a separate branch, in a separate workflow. This way they can't write to the main cache and the artifacts are isolated to that workflow (even though we don't use any other artifacts right now).

The price for this is that there are more workflow runs, and that we have to keep the build branch in sync with main, so the same code is run.